### PR TITLE
export AWS_PROFILE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.installed.cfg
 /.python-version
 /.vagrant
+/.idea
 
 __pycache__
 *.pyc

--- a/src/awsenv/__init__.py
+++ b/src/awsenv/__init__.py
@@ -162,12 +162,14 @@ class AWSProfile(object):
             return "\n".join([
                 "{}AWS_ACCESS_KEY_ID={}".format("export " if export else "", self.aws_access_key_id),
                 "{}AWS_SECRET_ACCESS_KEY={}".format("export " if export else "", self.aws_secret_access_key),
-                "{}AWS_SESSION_TOKEN={}".format("export " if export else "", self.aws_session_token)
+                "{}AWS_SESSION_TOKEN={}".format("export " if export else "", self.aws_session_token),
+                "{}AWS_PROFILE={}".format("export " if export else "", self.name)
             ])
         else:
             return "\n".join([
                 "{}AWS_ACCESS_KEY_ID={}".format("export " if export else "", self.aws_access_key_id),
-                "{}AWS_SECRET_ACCESS_KEY={}".format("export " if export else "", self.aws_secret_access_key)
+                "{}AWS_SECRET_ACCESS_KEY={}".format("export " if export else "", self.aws_secret_access_key),
+                "{}AWS_PROFILE={}".format("export " if export else "", self.name)
             ])
     @property
     def aws_access_key_id(self):

--- a/src/awsenv/tests.py
+++ b/src/awsenv/tests.py
@@ -164,9 +164,9 @@ class AWSProfileTestCase(unittest.TestCase):
         self.assertEqual('session token', fixture.session_token)
 
     def test_format(self):
-        fixture = AWSProfile(None, 'a', 'b', 'c')
-        result_export = "export AWS_ACCESS_KEY_ID=a\nexport AWS_SECRET_ACCESS_KEY=b\nexport AWS_SESSION_TOKEN=c"
-        result_no_export = "AWS_ACCESS_KEY_ID=a\nAWS_SECRET_ACCESS_KEY=b\nAWS_SESSION_TOKEN=c"
+        fixture = AWSProfile('p', 'a', 'b', 'c')
+        result_export = "export AWS_ACCESS_KEY_ID=a\nexport AWS_SECRET_ACCESS_KEY=b\nexport AWS_SESSION_TOKEN=c\nexport AWS_PROFILE=p"
+        result_no_export = "AWS_ACCESS_KEY_ID=a\nAWS_SECRET_ACCESS_KEY=b\nAWS_SESSION_TOKEN=c\nAWS_PROFILE=p"
 
         self.assertEqual(result_export, fixture.format())
         self.assertEqual(result_no_export, fixture.format(export=False))


### PR DESCRIPTION
Exporting AWS_PROFILE=osm for shells.
This is useful to be displayed at shell command prompts and is e.g. already implemented by oh-my-zsh themes.
<img src="https://i.ibb.co/thkB30K/Screenshot-from-2019-08-13-20-00-00.png" alt="AWS profile in shell prompt" border="0">
